### PR TITLE
Upload all JS files, not just the maps

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -30,7 +30,16 @@ curl -sSf "${API}/releases/" \
   -X POST \
   -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
   -H 'Content-Type: application/json' \
-  -d "{\"version\": \"${SOURCE_VERSION}\"}" \
+  -d '
+  {
+    "version": "${SOURCE_VERSION}",
+    "refs": [{
+      "repository": :"${SOURCEMAP_REPO}",
+      "commit": "${SOURCE_VERSION}"
+    }],
+    "projects": ["${SOURCEMAP_SENTRY_PROJECT}"]
+  }
+  '
   >/dev/null
 
 # Retrieve files

--- a/bin/compile
+++ b/bin/compile
@@ -33,7 +33,10 @@ curl -sSf "${API}/releases/" \
   -d "
   {
     \"version\": \"${SOURCE_VERSION}\",
-    \"ref\": \"${SOURCE_VERSION}\",
+    \"refs\": [{
+      \"repository\": \"${SOURCEMAP_REPO}\",
+      \"commit\": \"${SOURCE_VERSION}\"
+    }],
     \"projects\": [\"${SOURCEMAP_SENTRY_PROJECT}\"]
   }
   "

--- a/bin/compile
+++ b/bin/compile
@@ -21,7 +21,7 @@ if [[ ! -f "${JQ}" ]]; then
     chmod +x "${JQ}"
 fi
 
-API="https://sentry.io/api/0/projects/${SOURCEMAP_SENTRY_PROJECT}"
+API="https://sentry.io/api/0/organizations/${SOURCEMAP_SENTRY_ORG}"
 
 # Create a release
 echo "-----> Creating Sentry release ${SOURCE_VERSION} for project ${SOURCEMAP_SENTRY_PROJECT}"

--- a/bin/compile
+++ b/bin/compile
@@ -52,11 +52,13 @@ curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
 
 # Upload the sourcemaps
 cd "${build}/${SOURCEMAP_DIR}"
-for map in {*.js,*.js.map}
+for map in $(find -name '*.js' -or -name '*.js.map');
 do
     if [ "$map" = "*.js" ] || [ "$map" = "*.js.map" ]; then
       continue
     fi
+
+    echo "Uploading or updating ${map}"
 
     sum=$(sha1sum "${map}" | cut -c -40)
     name="${SOURCEMAP_URL_PREFIX}${map}"

--- a/bin/compile
+++ b/bin/compile
@@ -30,16 +30,16 @@ curl -sSf "${API}/releases/" \
   -X POST \
   -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
   -H 'Content-Type: application/json' \
-  -d '
+  -d "
   {
-    "version": "${SOURCE_VERSION}",
-    "refs": [{
-      "repository": :"${SOURCEMAP_REPO}",
-      "commit": "${SOURCE_VERSION}"
+    \"version\": \"${SOURCE_VERSION}\",
+    \"refs\": [{
+      \"repository\": :\"${SOURCEMAP_REPO}\",
+      \"commit\": \"${SOURCE_VERSION}\"
     }],
-    "projects": ["${SOURCEMAP_SENTRY_PROJECT}"]
+    \"projects\": [\"${SOURCEMAP_SENTRY_PROJECT}\"]
   }
-  '
+  "
   >/dev/null
 
 # Retrieve files

--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ build=$(cd "$1/" && pwd)
 cache=$(cd "$2/" && pwd)
 env_dir=$(cd "$3/" && pwd)
 
-for key in SOURCEMAP_DIR SOURCEMAP_SENTRY_TOKEN SOURCEMAP_SENTRY_PROJECT do
+for key in SOURCEMAP_DIR SOURCEMAP_SENTRY_TOKEN SOURCEMAP_SENTRY_PROJECT; do
     [[ -f "${env_dir}/${key}" ]] && export "$key=$(cat "${env_dir}/${key}")"
     [[ -z "${!key}" ]] && echo "-----> ${key} is missing or empty: unable to continue." && exit 1
 done

--- a/bin/compile
+++ b/bin/compile
@@ -26,7 +26,7 @@ API="https://sentry.io/api/0/organizations/${SOURCEMAP_SENTRY_ORG}"
 # Create a release
 echo "-----> Creating Sentry release ${SOURCE_VERSION} for project ${SOURCEMAP_SENTRY_PROJECT}"
 
-curl --trace-ascii /dev/stdout -vsSf "${API}/releases/" \
+curl -sSf "${API}/releases/" \
   -X POST \
   -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
   -H 'Content-Type: application/json' \

--- a/bin/compile
+++ b/bin/compile
@@ -43,7 +43,7 @@ curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
 
 # Upload the sourcemaps
 cd "${build}/${SOURCEMAP_DIR}"
-for map in {*.js.map, *.js}; do
+for map in *.js.map; do
     sum=$(sha1sum "${map}" | cut -c -40)
     name="${map}"
     res=($(${JQ} -r ". | map(select(.name == \"${name}\")) | first | .id + \" \" + (.sha1 // \"\")" "${files}"))

--- a/bin/compile
+++ b/bin/compile
@@ -26,7 +26,7 @@ API="https://sentry.io/api/0/organizations/${SOURCEMAP_SENTRY_ORG}"
 # Create a release
 echo "-----> Creating Sentry release ${SOURCE_VERSION} for project ${SOURCEMAP_SENTRY_PROJECT}"
 
-curl --trace-ascii /dev/stdout -sSf "${API}/releases/" \
+curl --trace-ascii /dev/stdout -vsSf "${API}/releases/" \
   -X POST \
   -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
   -H 'Content-Type: application/json' \

--- a/bin/compile
+++ b/bin/compile
@@ -61,7 +61,7 @@ do
     echo "Uploading or updating ${map}"
 
     sum=$(sha1sum "${map}" | cut -c -40)
-    name="${SOURCEMAP_URL_PREFIX}${map}"
+    name="${SOURCEMAP_URL_PREFIX}${map#"./"}"
     res=($(${JQ} -r ". | map(select(.name == \"${name}\")) | first | .id + \" \" + (.sha1 // \"\")" "${files}"))
 
     if [[ "${res[0]}" == "" ]]; then

--- a/bin/compile
+++ b/bin/compile
@@ -54,6 +54,10 @@ curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
 cd "${build}/${SOURCEMAP_DIR}"
 for map in {*.js,*.js.map}
 do
+    if [ "$map" = "*.js" ] || [ "$map" = "*.js.map" ]; then
+      continue
+    fi
+
     sum=$(sha1sum "${map}" | cut -c -40)
     name="${SOURCEMAP_URL_PREFIX}${map}"
     res=($(${JQ} -r ". | map(select(.name == \"${name}\")) | first | .id + \" \" + (.sha1 // \"\")" "${files}"))

--- a/bin/compile
+++ b/bin/compile
@@ -43,7 +43,8 @@ curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
 
 # Upload the sourcemaps
 cd "${build}/${SOURCEMAP_DIR}"
-for map in *.js.map; do
+for map in {*.js,*.js.map}
+do
     sum=$(sha1sum "${map}" | cut -c -40)
     name="${map}"
     res=($(${JQ} -r ". | map(select(.name == \"${name}\")) | first | .id + \" \" + (.sha1 // \"\")" "${files}"))

--- a/bin/compile
+++ b/bin/compile
@@ -43,7 +43,7 @@ curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
 
 # Upload the sourcemaps
 cd "${build}/${SOURCEMAP_DIR}"
-for map in *.js*; do
+for map in {*.js.map, *.js}; do
     sum=$(sha1sum "${map}" | cut -c -40)
     name="${map}"
     res=($(${JQ} -r ". | map(select(.name == \"${name}\")) | first | .id + \" \" + (.sha1 // \"\")" "${files}"))

--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ build=$(cd "$1/" && pwd)
 cache=$(cd "$2/" && pwd)
 env_dir=$(cd "$3/" && pwd)
 
-for key in SOURCEMAP_DIR SOURCEMAP_SENTRY_TOKEN SOURCEMAP_SENTRY_PROJECT; do
+for key in SOURCEMAP_DIR SOURCEMAP_SENTRY_TOKEN SOURCEMAP_SENTRY_PROJECT SOURCEMAP_URL_PREFIX; do
     [[ -f "${env_dir}/${key}" ]] && export "$key=$(cat "${env_dir}/${key}")"
     [[ -z "${!key}" ]] && echo "-----> ${key} is missing or empty: unable to continue." && exit 1
 done
@@ -46,7 +46,7 @@ cd "${build}/${SOURCEMAP_DIR}"
 for map in {*.js,*.js.map}
 do
     sum=$(sha1sum "${map}" | cut -c -40)
-    name="${map}"
+    name="${SOURCEMAP_URL_PREFIX}${map}"
     res=($(${JQ} -r ". | map(select(.name == \"${name}\")) | first | .id + \" \" + (.sha1 // \"\")" "${files}"))
 
     if [[ "${res[0]}" == "" ]]; then

--- a/bin/compile
+++ b/bin/compile
@@ -33,10 +33,7 @@ curl -sSf "${API}/releases/" \
   -d "
   {
     \"version\": \"${SOURCE_VERSION}\",
-    \"refs\": [{
-      \"repository\": \"${SOURCEMAP_REPO}\",
-      \"commit\": \"${SOURCE_VERSION}\"
-    }],
+    \"ref\": \"${SOURCE_VERSION}\",
     \"projects\": [\"${SOURCEMAP_SENTRY_PROJECT}\"]
   }
   "

--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ build=$(cd "$1/" && pwd)
 cache=$(cd "$2/" && pwd)
 env_dir=$(cd "$3/" && pwd)
 
-for key in SOURCEMAP_DIR SOURCEMAP_SENTRY_TOKEN SOURCEMAP_SENTRY_PROJECT SOURCEMAP_URL_PREFIX; do
+for key in SOURCEMAP_DIR SOURCEMAP_SENTRY_TOKEN SOURCEMAP_SENTRY_PROJECT SOURCEMAP_SENTRY_ORG SOURCEMAP_REPO SOURCEMAP_URL_PREFIX; do
     [[ -f "${env_dir}/${key}" ]] && export "$key=$(cat "${env_dir}/${key}")"
     [[ -z "${!key}" ]] && echo "-----> ${key} is missing or empty: unable to continue." && exit 1
 done

--- a/bin/compile
+++ b/bin/compile
@@ -43,7 +43,7 @@ curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
 
 # Upload the sourcemaps
 cd "${build}/${SOURCEMAP_DIR}"
-for map in *.js.map; do
+for map in *.js*; do
     sum=$(sha1sum "${map}" | cut -c -40)
     name="${SOURCEMAP_URL_PREFIX}${map}"
     res=($(${JQ} -r ". | map(select(.name == \"${name}\")) | first | .id + \" \" + (.sha1 // \"\")" "${files}"))

--- a/bin/compile
+++ b/bin/compile
@@ -34,7 +34,7 @@ curl -sSf "${API}/releases/" \
   {
     \"version\": \"${SOURCE_VERSION}\",
     \"refs\": [{
-      \"repository\": :\"${SOURCEMAP_REPO}\",
+      \"repository\": \"${SOURCEMAP_REPO}\",
       \"commit\": \"${SOURCE_VERSION}\"
     }],
     \"projects\": [\"${SOURCEMAP_SENTRY_PROJECT}\"]

--- a/bin/compile
+++ b/bin/compile
@@ -26,7 +26,7 @@ API="https://sentry.io/api/0/organizations/${SOURCEMAP_SENTRY_ORG}"
 # Create a release
 echo "-----> Creating Sentry release ${SOURCE_VERSION} for project ${SOURCEMAP_SENTRY_PROJECT}"
 
-curl -sSf "${API}/releases/" \
+curl --trace-ascii /dev/stdout -sSf "${API}/releases/" \
   -X POST \
   -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
   -H 'Content-Type: application/json' \

--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ build=$(cd "$1/" && pwd)
 cache=$(cd "$2/" && pwd)
 env_dir=$(cd "$3/" && pwd)
 
-for key in SOURCEMAP_DIR SOURCEMAP_SENTRY_TOKEN SOURCEMAP_SENTRY_PROJECT SOURCEMAP_URL_PREFIX; do
+for key in SOURCEMAP_DIR SOURCEMAP_SENTRY_TOKEN SOURCEMAP_SENTRY_PROJECT do
     [[ -f "${env_dir}/${key}" ]] && export "$key=$(cat "${env_dir}/${key}")"
     [[ -z "${!key}" ]] && echo "-----> ${key} is missing or empty: unable to continue." && exit 1
 done
@@ -45,7 +45,7 @@ curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
 cd "${build}/${SOURCEMAP_DIR}"
 for map in *.js*; do
     sum=$(sha1sum "${map}" | cut -c -40)
-    name="${SOURCEMAP_URL_PREFIX}${map}"
+    name="${map}"
     res=($(${JQ} -r ". | map(select(.name == \"${name}\")) | first | .id + \" \" + (.sha1 // \"\")" "${files}"))
 
     if [[ "${res[0]}" == "" ]]; then


### PR DESCRIPTION
Sentry takes advantage of the minified JS files in addition to the maps, as noted in their [documentation](https://docs.sentry.io/clients/javascript/sourcemaps/):

> You will want to upload all dist files (i.e. the minified/shipped JS), the referenced sourcemaps, and the files that those sourcemaps point to.

With more colour later on:

> Note: You dont have to upload the source files (ref’d by sourcemaps), but without them the grouping algorithm will not be as strong, and the UI will not show any contextual source.

---

I made the smallest possible change to allow the functionality and can confirm that it's working on my Heroku builds. You can test using my forked buildpack. 😄 